### PR TITLE
Loaded front from connection-aware URL

### DIFF
--- a/zero_signal.cpbranding/index.html
+++ b/zero_signal.cpbranding/index.html
@@ -22,7 +22,7 @@
     </style>
 </noscript>
 
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
+<link href="//fonts.googleapis.com/css?family=Open+Sans:400,600,300" rel="stylesheet" type="text/css">
 <link href="<cpanel Branding="file(local.css,0,$brandingpkg,0,0,1,1,1)">" rel="stylesheet" type="text/css" />
 
 <!--[if lt IE 7]>

--- a/zero_signal.cpbranding/stdheader.html
+++ b/zero_signal.cpbranding/stdheader.html
@@ -9,7 +9,7 @@
     <cpanel Branding="include(sprites_yui.html)">
 </style>
 
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
+<link href="//fonts.googleapis.com/css?family=Open+Sans:400,600,300" rel="stylesheet" type="text/css">
 <link href="<cpanel Branding="file(local.css,0,$brandingpkg,0,0,1,1,1)">" rel="stylesheet" type="text/css" />
 <!--[if gt IE 6]>
 <style type="text/css">


### PR DESCRIPTION
When using a https connection, Google Chrome would throw a warning that you are loading unsecure content, with a secure connection.  Now, the correct URL will load, http when on an http connection, and https when on a https connection
